### PR TITLE
add global variable to disable default mappings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,26 +41,31 @@ Debugger commands::
    [usage:] dbg command [options]
    - quit    :: exit the debugger
    - run     :: continue execution until a breakpoint is reached or the program ends
-            shortcut: \r
+            default shortcut: \r
    - stop    :: exit the debugger
    - over    :: step over next function call
-            shortcut: \o
+            default shortcut: \o
    - watch   :: execute watch functions
-            shortcut: \w
+            default shortcut: \w
    - up      :: go up the stack
-            shortcut: \u
+            default shortcut: \u
    - here    :: continue execution until the cursor (tmp breakpoint)
-            shortcut: \h
+            default shortcut: \h
    - down    :: go down the stack
-            shortcut: \d
+            default shortcut: \d
    - exit    :: exit the debugger
    - eval    :: eval some code
    - break   :: set a breakpoint
-            shortcut: \b
+            default shortcut: \b
    - into    :: step into next function call
-            shortcut: \i
+            default shortcut: \i
    - out     :: step out of current function call
-            shortcut: \t
+            default shortcut: \t
+
+To disable the default mappings you can set the "g:vim_debug_disable_mappings" to a value
+different than 0 in the debugger.vim file.
+
+Note: The debugger.vim file is installed by the install-vim-debug.py command in the ``$VIM/plugins/`` directory.
 
 Screenshot: `[full size]
 <http://jaredforsyth.com/media/uploads/images/vim_debug.jpeg>`_

--- a/bin/install-vim-debug.py
+++ b/bin/install-vim-debug.py
@@ -13,6 +13,10 @@ if !has("python")
     finish
 endif
 
+" set this to 0 to enable the automatic mappings
+" any other value will disable the mappings
+let g:vim_debug_disable_mappings = 0
+
 python << EOF
 import vim
 try:

--- a/vim_debug/new_debugger.py
+++ b/vim_debug/new_debugger.py
@@ -58,7 +58,12 @@ class Registrar:
 class CmdRegistrar(Registrar):
     def add(self, func, args, kwds):
         lead = kwds.get('lead', '')
-        if lead:
+
+        disabled_mappings = False
+        if vim.eval("exists('g:vim_debug_disable_mappings')") != "0":
+            disabled_mappings = vim.eval("g:vim_debug_disable_mappings") != "1"
+
+        if lead and not disabled_mappings:
             vim.command('map <Leader>%s :Dbg %s<cr>' % (lead, args[0]))
         dct = {'function':func, 'options':kwds}
         for name in args:


### PR DESCRIPTION
This code allows the user to disable the default mappings.
This way, mapping conflicts can be avoided and the user can define its own mappings for the debugger.
