### PR TITLE
State only Python 2 but not 3 in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 
 This plugin creates an integrated debugging environment in VIM.
 
-It supports python and php.
+It supports Python 2 and PHP.
 
 
 Features


### PR DESCRIPTION
Since Python 3 isn't supported, save people's time by explicitly stating that in the frontpage.