### PR TITLE
Make this into a proper vim plugin.

### DIFF
--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-
-text = '''\
 " DBGp client: a remote debugger interface to the DBGp protocol
 "
 " Script Info and Documentation  {{{
@@ -16,18 +13,25 @@ endif
 " set this to 0 to enable the automatic mappings
 " any other value will disable the mappings
 let g:vim_debug_disable_mappings = 0
+let g:has_debug = 0
 
 python << EOF
 import vim
+import sys
+import os.path
+
+pylib_dir = os.path.join(vim.eval("expand('<sfile>:p:h')"), '..')
+pylib_dir = os.path.abspath(pylib_dir)
+sys.path.insert(0, pylib_dir)
 try:
     from vim_debug.commands import debugger_cmd
-    vim.command('let has_debug = 1')
-except ImportError, e:
-    vim.command('let has_debug = 0')
+    vim.command('let g:has_debug = 1')
+except ImportError as e:
     print 'python module vim_debug not found...'
+    raise
 EOF
 
-if !has_debug
+if !g:has_debug
     finish
 endif
 
@@ -38,32 +42,3 @@ hi DbgCurrent term=reverse ctermfg=White ctermbg=Red gui=reverse
 hi DbgBreakPt term=reverse ctermfg=White ctermbg=Green gui=reverse
 sign define current text=->  texthl=DbgCurrent linehl=DbgCurrent
 sign define breakpt text=B>  texthl=DbgBreakPt linehl=DbgBreakPt
-'''
-
-import os, platform, sys
-which = platform.system()
-user = os.path.expanduser('~')
-vim_dir = os.environ.get('VIM')
-if vim_dir is None:
-    if (which == 'Linux') or (which == 'Darwin'):
-        vim_dir = os.path.join(user, '.vim')
-    elif which == 'Windows':
-        vim_dir = os.path.join(user, 'vimfiles')
-    else:
-        print>>sys.stderr, 'No $VIM directory found'
-        sys.exit(1)
-vim_dir = os.path.join(vim_dir, 'plugin')
-if not os.path.exists(vim_dir):
-    os.makedirs(vim_dir)
-fname = os.path.join(vim_dir, 'debugger.vim')
-if os.path.exists(fname):
-    print>>sys.stderr, 'Looks like it\'s already installed (at %s)' % fname
-    sys.exit(2)
-print 'installing to %s' % fname
-open(fname, 'w').write(text)
-print 'finished'
-
-
-
-
-# vim: et sw=4 sts=4


### PR DESCRIPTION
vim plugins are normally not distributed via ``pip``, but through [pathogen](https://github.com/tpope/vim-pathogen), [Vundle](https://github.com/gmarik/vundle), [vim-plug](https://github.com/junegunn/vim-plug) or something like that.

This pull request changes ``vim-debug`` so that it works when installed via these means (yes, of course, you still have to install ``dbgp``, but nothing else).