### PR TITLE
Add support for passing arguments to the Python script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Usage
 To start your debug session, use the following variants::
 
    Usage: Dbg - (no auto start)
-          Dbg . (autostart current file -- python)
+          Dbg . [args] (autostart current file -- python)
           Dbg url (autostart a URL -- PHP)
           Dbg num (autostart a past url -- PHP)
 

--- a/vim_debug/commands.py
+++ b/vim_debug/commands.py
@@ -57,7 +57,7 @@ def cmd(name, help='', plain=False):
 
 debugger = None
 
-def start(url = None):
+def start(url = None, *args):
     global debugger
     if debugger and debugger.started:
         return
@@ -85,7 +85,8 @@ def start(url = None):
                 if not (os.path.exists(fname) and fname.endswith('.py')):
                     print 'Current file is not python (or doesn\'t exist on your hard drive)'
                     return
-                debugger.start_py(fname)
+                full_cmds = "{} {}".format(fname, " ".join(args))
+                debugger.start_py(full_cmds)
             elif url == '-':
                 debugger.start()
             else:

--- a/vim_debug/new_debugger.py
+++ b/vim_debug/new_debugger.py
@@ -108,8 +108,8 @@ class Debugger:
             PYDBGP = PYDBGP + '/../EGG-INFO/scripts/pydbgp.py'
             subprocess.Popen(('python.exe',PYDBGP, '-d', 'localhost:9000', fname), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         else:
-            all_cmds = ('pydbgp.py', '-d', 'localhost:9000') + tuple(fname.split())
-            subprocess.Popen(all_cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            with_args = ('pydbgp.py', '-d', 'localhost:9000') + tuple(fname.split())
+            subprocess.Popen(with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         self._type = 'python'
         return self.start()

--- a/vim_debug/new_debugger.py
+++ b/vim_debug/new_debugger.py
@@ -108,7 +108,8 @@ class Debugger:
             PYDBGP = PYDBGP + '/../EGG-INFO/scripts/pydbgp.py'
             subprocess.Popen(('python.exe',PYDBGP, '-d', 'localhost:9000', fname), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         else:
-            subprocess.Popen(('pydbgp.py', '-d', 'localhost:9000', fname), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            all_cmds = ('pydbgp.py', '-d', 'localhost:9000') + tuple(fname.split())
+            subprocess.Popen(all_cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         self._type = 'python'
         return self.start()


### PR DESCRIPTION
Only tested with :Dbg . arg1 arg2 arg2

Not sure whether the situation applies to the other method of invoking the script.

Thanks for the nice job and it is a lifesaver for me.