### PR TITLE
docs: Fix a few typos

### DIFF
--- a/vim_debug/debugger.py
+++ b/vim_debug/debugger.py
@@ -43,7 +43,7 @@ from protocol import DbgProtocol
 class BreakPointManager:
     """ Breakpoint manager class """
     def __init__(self):
-        """ initalize """
+        """ initialize """
         self.breakpt = {}
         self.revmap = {}
         self.startbno = 10000
@@ -175,7 +175,7 @@ class Debugger:
     # Internal message handlers
     #
     def handle_msg(self, res):
-        """ call appropraite message handler member function, handle_XXX() """
+        """ call appropriate message handler member function, handle_XXX() """
         fc = res.firstChild
         try:
             handler = getattr(self, 'handle_' + fc.tagName)
@@ -184,7 +184,7 @@ class Debugger:
             print 'Debugger.handle_'+fc.tagName+'() not found, please see the LOG___WINDOW'
         self.ui.go_srcview()
     def handle_response(self, res):
-        """ call appropraite response message handler member function, handle_response_XXX() """
+        """ call appropriate response message handler member function, handle_response_XXX() """
         if res.firstChild.hasAttribute('reason') and res.firstChild.getAttribute('reason') == 'error':
             self.handle_response_error(res)
             return

--- a/vim_debug/ui.py
+++ b/vim_debug/ui.py
@@ -61,7 +61,7 @@ class DebugUI:
             file, line, tid = self.breaks.pop(bid)
             vim.command('sign unplace %d file=%s' % (tid, file))
 
-        # destory all created windows
+        # destroy all created windows
         self.destroy()
 
         # restore session


### PR DESCRIPTION
There are small typos in:
- vim_debug/debugger.py
- vim_debug/ui.py

Fixes:
- Should read `appropriate` rather than `appropraite`.
- Should read `initialize` rather than `initalize`.
- Should read `destroy` rather than `destory`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md